### PR TITLE
Add config file for Vagrantfile

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,17 @@
+---
+# The kubernetes cluster comprises of:
+#   - master: has the etcd, schedule node ...
+#   - devel: node where the development happens
+#   - nodes: 0 to N nodes in the cluster, configures via parameter
+
+# Number of nodes used in the kubernetes cluster
+nodes: 2
+
+
+# The network base for local dev cluster
+network_base: "192.168.50"
+# Cluster starting segment appended to network base: eg. 192.168.50.20
+start_segment: "20"
+
+# Base os of the cluster
+box_image: "centos/7"


### PR DESCRIPTION
To be more flexible and more user friendly
this patch adds the config file used
to configure the dev environment.

Originally the env variables were used,
but this is not a transparent way of
configuration.

@cynepco3hahue if you do not have objection please review and merge.