### PR TITLE
kubevirt-common: clean & update kubevirt repository

### DIFF
--- a/common/roles/kubevirt/tasks/main.yml
+++ b/common/roles/kubevirt/tasks/main.yml
@@ -11,13 +11,17 @@
     repo: https://github.com/kubevirt/kubevirt.git
     dest: "{{ go_path }}/{{ kubevirt_dir }}"
     clone: yes
-    update: no
 
 - name: copy config-local to kubevirt directory
   template:
     src: config-local.j2
     dest: "{{ go_path }}/{{ kubevirt_dir }}/hack/config-local.sh"
     mode: 0644
+
+- name: make distclean
+  make:
+    chdir: "{{ go_path }}/{{ kubevirt_dir }}"
+    target: distclean
 
 - name: make binaries
   make:


### PR DESCRIPTION
when running playbook second time, it would be good to fetch new
changes and clean old build.