### PR TITLE
deploy-kubernetes: replace golang role, we removed it past

### DIFF
--- a/common/roles/kubevirt/tasks/main.yml
+++ b/common/roles/kubevirt/tasks/main.yml
@@ -11,17 +11,18 @@
     repo: https://github.com/kubevirt/kubevirt.git
     dest: "{{ go_path }}/{{ kubevirt_dir }}"
     clone: yes
+    force: yes
+
+- name: make distclean
+  make:
+    chdir: "{{ go_path }}/{{ kubevirt_dir }}"
+    target: distclean
 
 - name: copy config-local to kubevirt directory
   template:
     src: config-local.j2
     dest: "{{ go_path }}/{{ kubevirt_dir }}/hack/config-local.sh"
     mode: 0644
-
-- name: make distclean
-  make:
-    chdir: "{{ go_path }}/{{ kubevirt_dir }}"
-    target: distclean
 
 - name: make binaries
   make:

--- a/deploy-kubernetes.yml
+++ b/deploy-kubernetes.yml
@@ -2,11 +2,15 @@
 - hosts: all
   remote_user: root
   vars_files:
-    - "{{ playbook_dir }}/kubernetes/vars/default_vars.yml"
-    - "{{ playbook_dir }}/common/vars/default_vars.yml"
+  pre_tasks:
+    - name: override roles variables
+      include_vars: "{{ item }}"
+      with_items:
+        - "{{ playbook_dir }}/kubernetes/vars/default_vars.yml"
+        - "{{ playbook_dir }}/common/vars/default_vars.yml"
   roles:
     - "{{ playbook_dir }}/kubernetes/roles/prerequisites"
-    - "{{ playbook_dir }}/common/roles/golang"
+    - "andrewrothstein.go-dev"
     - "{{ playbook_dir }}/common/roles/kubevirt"
 
 - hosts: masters
@@ -22,5 +26,3 @@
     - "{{ playbook_dir }}/kubernetes/vars/default_vars.yml"
   roles:
     - "{{ playbook_dir }}/kubernetes/roles/node"
-
-


### PR DESCRIPTION
kubevirt-deploy.yml playbook fails on absence of golang role.