### PR TITLE
automation: Fix log collection

### DIFF
--- a/automation/run.sh
+++ b/automation/run.sh
@@ -24,9 +24,8 @@ collect_logs() {
         -name lago.log \
         -exec cp {} "$artifacts_dir" \;
 
-    find . \
-        -name ansible.log \
-        -exec cp {} "$artifacts_dir" \;
+    
+    cp ansible.log "$artifacts_dir"
 }
 
 cleanup() {
@@ -85,7 +84,7 @@ main() {
     local run_path="$(get_run_path "$cluster_type")"
     local args=("prefix=$run_path")
 
-    trap 'cleanup "$run_path"' EXIT
+    trap "cleanup $run_path" EXIT
 
     set_params
     install_requirements


### PR DESCRIPTION
- Fix the quoting of the trap.
  The current implementation caused "$run_path" to be evaluated to
  the empty string, because it occurred outside of the main function.

- Don't use "find" to copy "ansible.log", since it can cause a race where
  "find" copies "ansible.log" and then finds it again in the exported
  artifacts dir.

Signed-off-by: gbenhaim <galbh2@gmail.com>