### PR TITLE
deploy-with-lago: Add more storage

### DIFF
--- a/LagoInitFile.yml
+++ b/LagoInitFile.yml
@@ -29,7 +29,12 @@ host-settings: &nodes-settings
         name: docker_storage
         dev: sdb
         format: raw
-
+      - comment: /var/lib/docker
+        size: 10G
+        type: empty
+        name: docker_lib
+        dev: sdc
+        format: raw
 domains:
   lago-master:
     <<: *vm-common-settings
@@ -43,11 +48,23 @@ domains:
         name: root
         dev: sda
         format: qcow2
+      - comment: Docker Storage
+        size: 10G
+        type: empty
+        name: docker_storage
+        dev: sdb
+        format: raw
+      - comment: /var/lib/docker
+        size: 10G
+        type: empty
+        name: docker_lib
+        dev: sdc
+        format: raw
       - comment: Main NFS device
         size: 101G
         type: empty
         name: nfs
-        dev: sdb
+        dev: sdd
         format: raw
 
   lago-node0:

--- a/deploy-with-lago.yml
+++ b/deploy-with-lago.yml
@@ -39,7 +39,30 @@
         delay: 10
       delegate_to: localhost
       connection: local
+    - name: Mount docker_lib
+      shell: |
+        disk="/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_3"
+        mount_path="/var/lib/docker"
+        mkdir -p "$mount_path"
+        mkfs.ext4 -F "$disk"
+        echo -e "${disk}\t${mount_path}\text4\tdefaults\t0 0" >> /etc/fstab
+        mount "$disk" "$mount_path"
+    - name: Set docker storage disk path
+      set_fact:
+        docker_dev: "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_2"
 
+- hosts: nfs
+  any_errors_fatal: True
+  tasks:
+    - name: Mount nfs storage
+      shell: |
+        disk="/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_4"
+        mount_path="/opt"
+        mkdir -p "$mount_path"
+        mkfs.ext4 -F "$disk"
+        echo -e "${disk}\t${mount_path}\text4\tdefaults\t0 0" >> /etc/fstab
+        mount "$disk" "$mount_path"
+    
 - hosts: lago-node0
   tasks:
     - name: Mark lago-node0 as infra


### PR DESCRIPTION
- Add 10GB (sparse) disk and mount it to /var/lib/docker (needed when building
  Kubevirt's containers).

- Mount 100GB disk (sparse) in /opt in the master's VM. This disk will be
  used for the nfs share.

- Set "docker_dev" variable which marks "docker-storage-setup" role
  which disk to use.

Signed-off-by: gbenhaim <galbh2@gmail.com>