### PR TITLE
Use stable Openshift release

### DIFF
--- a/inventory
+++ b/inventory
@@ -8,7 +8,6 @@ openshift_clock_enabled=true
 ansible_ssh_user=root
 openshift_master_identity_providers=[{'name': 'allow_all_auth', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]
 openshift_disable_check=memory_availability,disk_availability
-openshift_repos_enable_testing=True
 
 
 # BEGIN ANSIBLE BROKER CONFIG


### PR DESCRIPTION
Openshift 3.7 has been released, there is no need to use
the unstable repo.

Signed-off-by: gbenhaim <galbh2@gmail.com>