### PR TITLE
Deploy Kubevirt on openshift using kubevirt.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .lago
 openshift-ansible
 *.retry
+*.pyc

--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -1,2 +1,3 @@
 lago
 ansible-2.3.1.0-3.el7
+origin-clients

--- a/automation/check-patch.repos
+++ b/automation/check-patch.repos
@@ -1,2 +1,3 @@
 kvm-common-el7,http://mirror.centos.org/centos/7/virt/x86_64/kvm-common/
 lago,http://resources.ovirt.org/repos/lago/stable/0.0/rpm/$distro
+oc,http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/

--- a/automation/run.sh
+++ b/automation/run.sh
@@ -24,7 +24,6 @@ collect_logs() {
         -name lago.log \
         -exec cp {} "$artifacts_dir" \;
 
-    
     cp ansible.log "$artifacts_dir"
 }
 
@@ -79,8 +78,16 @@ install_requirements() {
 }
 
 main() {
+    # cluster_type: Openshift or Kubernetes
+    # mode:
+    #   release - install kubevirt with kubevirt.yaml,
+    #   and fetch kubevirt's containers from docker hub
+    #
+    #   dev - install kubevirt with the dev manifests, and
+    #   build kubevirt's containers on the vms
 
     local cluster_type="${CLUSTER_TYPE:-openshift}"
+    local mode="${MODE:-release}"
     local run_path="$(get_run_path "$cluster_type")"
     local args=("prefix=$run_path")
 
@@ -103,12 +110,13 @@ main() {
         exit 1
     fi
 
+    args+=("mode=$mode")
+
     ansible-playbook \
         -u root \
         -i inventory \
         -v \
         -e "${args[*]}" \
-        --skip-tags="kubevirt,go" \
         deploy-with-lago.yml
 }
 

--- a/automation/run.sh
+++ b/automation/run.sh
@@ -18,8 +18,16 @@ get_run_path() {
 collect_logs() {
     local run_path="$1"
     local artifacts_dir="exported-artifacts"
+    local vms_logs="${artifacts_dir}/vms_logs"
 
-    [[ -d "$artifacts_dir" ]] || mkdir exported-artifacts
+    mkdir -p "$vms_logs"
+
+    lago \
+        --workdir "$run_path" \
+        collect \
+        --output "$vms_logs" \
+        || :
+
     find "$run_path" \
         -name lago.log \
         -exec cp {} "$artifacts_dir" \;

--- a/deploy-openshift.yml
+++ b/deploy-openshift.yml
@@ -25,14 +25,13 @@
 
 - include: "{{ openshift_ansible_dir }}/playbooks/byo/config.yml"
 
-- hosts: all
-  remote_user: root
-  pre_tasks:
-    - name: override go-dev variables
-      include_vars: "{{ playbook_dir }}/common/vars/default_vars.yml"
-      tags: go
-  roles:
-    - role: "andrewrothstein.go-dev"
-      tags: go
-    - role: "{{ playbook_dir }}/common/roles/kubevirt"
-      tags: kubevirt
+- hosts: masters
+  tasks:
+    - name: Configure oc admin user for testing
+      shell: |
+        user_name="{{ admin_test_user_name | default('test_admin') }}"
+        oc login -u system:admin
+        oc get user "$user_name" || oc create user "$user_name"
+        oc adm policy add-cluster-role-to-user cluster-admin "$user_name"
+
+- include: "{{ playbook_dir }}/install-kubevirt-{{ mode }}.yml"

--- a/install-kubevirt-dev.yml
+++ b/install-kubevirt-dev.yml
@@ -1,0 +1,11 @@
+- hosts: all
+  remote_user: root
+  pre_tasks:
+    - name: override go-dev variables
+      include_vars: "{{ playbook_dir }}/common/vars/default_vars.yml"
+      tags: go
+  roles:
+    - role: "andrewrothstein.go-dev"
+      tags: go
+    - role: "{{ playbook_dir }}/common/roles/kubevirt"
+      tags: kubevirt

--- a/install-kubevirt-release.yml
+++ b/install-kubevirt-release.yml
@@ -1,0 +1,61 @@
+- hosts: all
+  tasks:
+    - debug:
+        msg: "gather facts"
+
+- hosts: localhost
+  connection: local
+  gather_facts: False
+  # unset http_proxy. required for running in the CI
+  environment:
+    http_proxy: ""
+  vars:
+    kubevirt_repo_url: "https://github.com/kubevirt/kubevirt.git"
+    kubevirt_repo_path: "{{ playbook_dir }}/kubevirt"
+    kubevirt_mf_template: "{{ kubevirt_repo_path }}/manifests/release/kubevirt.yaml.in"
+    kubevirt_mf: "{{ kubevirt_repo_path }}/manifests/release/kubevirt.yaml"
+    docker_prefix: kubevirt
+    docker_tag: latest
+    lib_oc_path: "{{ playbook_dir }}/openshift-ansible/roles/lib_openshift"
+  pre_tasks:
+    - name: Clone Kubevirt's repo
+      git:
+        repo: "{{ kubevirt_repo_url }}"
+        dest: "{{ kubevirt_repo_path }}"
+
+    - name: Generate kubevirt.yaml from template
+      template:
+        src: "{{ kubevirt_mf_template }}"
+        dest: "{{ kubevirt_mf }}"
+
+    # oc requires that the master will be resolvable
+    - name: Add master's fqdn to /etc/hosts
+      lineinfile:
+        path: /etc/hosts
+        line: "{{ hostvars['lago-master']['ansible_default_ipv4']['address'] }} {{ hostvars['lago-master']['ansible_fqdn'] }}"
+
+    - name: Login to Openshift
+      shell: |
+        user_name="{{ admin_test_user_name | default('test_admin') }}"
+        user_password="{{ admin_test_password | default('123456') }}"
+        master_fqdn="{{ hostvars['lago-master']['ansible_fqdn'] }}"
+
+        oc login \
+          -u "$user_name" \
+          -p "$user_password" \
+          --insecure-skip-tls-verify=true \
+          "https://${master_fqdn}:8443"
+
+    - name: Install Kubevirt
+      debug:
+        msg: "Installing Kubevirt"
+
+  roles:
+    - "{{ playbook_dir }}/openshift/roles/kubevirt"
+
+  post_tasks:
+    - name: List Kubevirt's reousrces
+      shell: |
+        oc project kube-system
+        oc get pods
+        oc get ds

--- a/openshift/roles/kubevirt/defaults/main.yml
+++ b/openshift/roles/kubevirt/defaults/main.yml
@@ -1,0 +1,3 @@
+project: "kube-system"
+state: present
+kconfig: ".kube/config"

--- a/openshift/roles/kubevirt/filter_plugins/kubevirt_filters.py
+++ b/openshift/roles/kubevirt/filter_plugins/kubevirt_filters.py
@@ -1,0 +1,44 @@
+import yaml
+from collections import defaultdict
+
+from ansible.errors import AnsibleError
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+def mf_to_dict(mf):
+    """
+    Split Kubevirt manifest into a dict:
+    kind -> list of dicts
+
+    Args:
+        mf (str): Path to a yaml file
+
+    Returns:
+        (dict)
+    """
+    d = defaultdict(list)
+
+    with open(mf) as f:
+        docs = yaml.safe_load_all(f)
+
+        for doc in docs:
+            kind = doc['kind']
+            name = doc['metadata']['name']
+            d[kind].append(
+                {
+                    'name': name,
+                    'manifest': doc
+                }
+            )
+
+    return dict(d)
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'mf_to_dict': mf_to_dict
+        }

--- a/openshift/roles/kubevirt/meta/main.yml
+++ b/openshift/roles/kubevirt/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- role: "{{ lib_oc_path }}"

--- a/openshift/roles/kubevirt/tasks/main.yml
+++ b/openshift/roles/kubevirt/tasks/main.yml
@@ -1,0 +1,47 @@
+- name: Get Openshift version
+  oc_version:
+    kubeconfig: "{{ kconfig }}"
+  register: oc_version
+
+- name: Normalize kubevirt.yaml
+  set_fact:
+    normalized_mf: "{{ kubevirt_mf | mf_to_dict }}"
+
+- name: Create project
+  oc_project:
+    name: "{{ project }}"
+    kubeconfig: "{{ kconfig }}"
+    state: "{{ state }}"
+
+- name: RBAC
+  include: "oc_obj_task.yml"
+  loop_control:
+    loop_var: kind
+  with_items:
+    - ServiceAccount
+    - ClusterRole
+    - ClusterRoleBinding
+
+- name: Create scc
+  oc_adm_policy_user:
+    resource_kind: scc
+    resource_name: privileged
+    user: "system:serviceaccount:{{ project }}:{{ item }}"
+    kubeconfig: "{{ kconfig }}"
+    state: "{{ state }}"
+  with_items:
+    - kubevirt-privileged
+
+- name: Create CustomResourceDefinition
+  shell: |
+    oc get "{{ item.name }}" || \
+    echo "{{ item.manifest | to_yaml }}" | oc create -f -
+  with_items: "{{ normalized_mf.CustomResourceDefinition }}"
+
+- name: Create kubevirt's pods
+  include: "oc_obj_task.yml"
+  loop_control:
+    loop_var: kind
+  with_items:
+    - Deployment
+    - DaemonSet

--- a/openshift/roles/kubevirt/tasks/oc_obj_task.yml
+++ b/openshift/roles/kubevirt/tasks/oc_obj_task.yml
@@ -1,0 +1,11 @@
+- name: "Running oc_obj wrapper"
+  oc_obj:
+    name: "{{ item.name }}"
+    kubeconfig: "{{ kconfig }}"
+    namespace: "{{ project }}"
+    kind: "{{ kind }}"
+    state: "{{ state }}"
+    content:
+      data: "{{ item.manifest }}"
+      path: "/tmp/{{ kind }}"
+  with_items: "{{ normalized_mf[kind] }}"


### PR DESCRIPTION
- Split the flow into two types: dev, release.

  The dev flows use the manifests from manifes/dev/* (from Kubevirt's
  repo) and build the containers on the VMs.

  The release flow uses kubevirt.yml, and fetches the containers from a
  remote registry.

- Add a role named "kubevirt" to openshift/roles which deploys Kubevirt
  using kubevirt.yml. At this moment "kubevirt.yml" is fetched from
  Kubevirt's repo. Some notes about the role:

	- This role will be the base for an APB.
	- The role assumes that the user is already login to the
	  cluster.
	- A path to kubevirt.yml should be supplied to the role.

- At this moment the ansible modules don't support creation of
  CustomResourceDefinition, thus use 'oc' command for the task.

- "install-kubevirt-release.yml" wraps the kubevirt role, and handlers
  the prerequisites tasks.

- Create a test user with admin rights on the cluster.

depends on https://github.com/kubevirt/kubevirt/pull/640
closes https://github.com/kubevirt-incubator/kubevirt-ansible/issues/28
closes https://github.com/kubevirt-incubator/kubevirt-ansible/issues/27
closes https://github.com/kubevirt-incubator/kubevirt-ansible/issues/5
part of https://github.com/kubevirt-incubator/kubevirt-ansible/issues/13

Signed-off-by: gbenhaim <galbh2@gmail.com>