### PR TITLE
Accelerate ci

### DIFF
--- a/deploy-with-lago.yml
+++ b/deploy-with-lago.yml
@@ -62,7 +62,7 @@
         mkfs.ext4 -F "$disk"
         echo -e "${disk}\t${mount_path}\text4\tdefaults\t0 0" >> /etc/fstab
         mount "$disk" "$mount_path"
-    
+
 - hosts: lago-node0
   tasks:
     - name: Mark lago-node0 as infra
@@ -71,8 +71,4 @@
           region: infra
           zone: default
 
-- include: deploy-openshift.yml
-  when: cluster_type is not defined or cluster_type == "openshift"
-
-- include: deploy-kubernetes.yml
-  when: cluster_type is defined and cluster_type == "kubernetes"
+- include: "deploy-{{ cluster_type | default('openshift') }}.yml"

--- a/openshift/roles/prerequisites/tasks/main.yml
+++ b/openshift/roles/prerequisites/tasks/main.yml
@@ -27,8 +27,3 @@
     update_cache: yes
   with_items:
     - "{{ openshift_packages }}"
-
-- name: upgrade all packages
-  yum:
-    name: '*'
-    state: latest


### PR DESCRIPTION
openshift: Stop updating all the packages
- It's time consuming.
- It makes the env less reproducible.

deploy-with-lago: Better condition for choosing cluster type
- Fewer lines of code
- Will save a lot of lines in ansible.log

